### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive TypeScript integration for the Buttondown newsletter service, providing both a CLI interface and a Model Context Protocol (MCP) server for managing newsletters, drafts, and analytics.
 
+<a href="https://glama.ai/mcp/servers/@The-Focus-AI/buttondown-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@The-Focus-AI/buttondown-mcp/badge" alt="Buttondown Server MCP server" />
+</a>
+
 ## Features
 
 - **Multiple Interfaces**:


### PR DESCRIPTION
This PR adds a badge for the [Buttondown MCP Server](https://glama.ai/mcp/servers/@The-Focus-AI/buttondown-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@The-Focus-AI/buttondown-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@The-Focus-AI/buttondown-mcp/badge" alt="Buttondown Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.